### PR TITLE
removing zip installation command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: "Release New Version"
 
-on:
-  push:
-    tags:
-      - 'v*.*.*'
+on: [push, pull_request]
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,25 +17,25 @@ jobs:
         run:  echo RELEASE_VERSION=${GITHUB_REF#refs/*/} >> $GITHUB_ENV && echo $RELEASE_VERSION
       - name: "Create ZIP"
         run: |
-          apt-get install zip
           (cd ${{ env.DIR_NAME }} && zip -r ../${{ env.ZIP_FILE_NAME }} .)
-      - name: Update the WEBSITE_RUN_FROM_PACKAGE token in the arm.json file.
-        env: 
-          URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.RELEASE_VERSION }}/${{ env.ZIP_FILE_NAME }}
-        run: jq --arg url "$URL" '.resources[4].resources[0].properties.WEBSITE_RUN_FROM_PACKAGE=$url' ./arm_template/${{ env.JSON_FILE_NAME }} | sponge ${{ env.JSON_FILE_NAME }}
-      - name: Create Release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.ZIP_FILE_NAME }}
-          asset_name: ${{ env.ZIP_FILE_NAME }}
-          tag: ${{ env.RELEASE_VERSION }}
-          overwrite: true
-          body: "Automatic release. See changelog for updates"
-      - name: Add ${{ env.JSON_FILE_NAME }} to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.JSON_FILE_NAME }}
-          asset_name: ${{ env.JSON_FILE_NAME }}
-          tag: ${{ env.RELEASE_VERSION }}
+          ls -al
+      # - name: Update the WEBSITE_RUN_FROM_PACKAGE token in the arm.json file.
+      #   env: 
+      #     URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.RELEASE_VERSION }}/${{ env.ZIP_FILE_NAME }}
+      #   run: jq --arg url "$URL" '.resources[4].resources[0].properties.WEBSITE_RUN_FROM_PACKAGE=$url' ./arm_template/${{ env.JSON_FILE_NAME }} | sponge ${{ env.JSON_FILE_NAME }}
+      # - name: Create Release
+      #   uses: svenstaro/upload-release-action@v2
+      #   with:
+      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #     file: ${{ env.ZIP_FILE_NAME }}
+      #     asset_name: ${{ env.ZIP_FILE_NAME }}
+      #     tag: ${{ env.RELEASE_VERSION }}
+      #     overwrite: true
+      #     body: "Automatic release. See changelog for updates"
+      # - name: Add ${{ env.JSON_FILE_NAME }} to release
+      #   uses: svenstaro/upload-release-action@v2
+      #   with:
+      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #     file: ${{ env.JSON_FILE_NAME }}
+      #     asset_name: ${{ env.JSON_FILE_NAME }}
+      #     tag: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: "Release New Version"
 
-on: [push, pull_request]
-
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -18,24 +20,23 @@ jobs:
       - name: "Create ZIP"
         run: |
           (cd ${{ env.DIR_NAME }} && zip -r ../${{ env.ZIP_FILE_NAME }} .)
-          ls -al
-      # - name: Update the WEBSITE_RUN_FROM_PACKAGE token in the arm.json file.
-      #   env: 
-      #     URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.RELEASE_VERSION }}/${{ env.ZIP_FILE_NAME }}
-      #   run: jq --arg url "$URL" '.resources[4].resources[0].properties.WEBSITE_RUN_FROM_PACKAGE=$url' ./arm_template/${{ env.JSON_FILE_NAME }} | sponge ${{ env.JSON_FILE_NAME }}
-      # - name: Create Release
-      #   uses: svenstaro/upload-release-action@v2
-      #   with:
-      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #     file: ${{ env.ZIP_FILE_NAME }}
-      #     asset_name: ${{ env.ZIP_FILE_NAME }}
-      #     tag: ${{ env.RELEASE_VERSION }}
-      #     overwrite: true
-      #     body: "Automatic release. See changelog for updates"
-      # - name: Add ${{ env.JSON_FILE_NAME }} to release
-      #   uses: svenstaro/upload-release-action@v2
-      #   with:
-      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #     file: ${{ env.JSON_FILE_NAME }}
-      #     asset_name: ${{ env.JSON_FILE_NAME }}
-      #     tag: ${{ env.RELEASE_VERSION }}
+      - name: Update the WEBSITE_RUN_FROM_PACKAGE token in the arm.json file.
+        env: 
+          URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.RELEASE_VERSION }}/${{ env.ZIP_FILE_NAME }}
+        run: jq --arg url "$URL" '.resources[4].resources[0].properties.WEBSITE_RUN_FROM_PACKAGE=$url' ./arm_template/${{ env.JSON_FILE_NAME }} | sponge ${{ env.JSON_FILE_NAME }}
+      - name: Create Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.ZIP_FILE_NAME }}
+          asset_name: ${{ env.ZIP_FILE_NAME }}
+          tag: ${{ env.RELEASE_VERSION }}
+          overwrite: true
+          body: "Automatic release. See changelog for updates"
+      - name: Add ${{ env.JSON_FILE_NAME }} to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.JSON_FILE_NAME }}
+          asset_name: ${{ env.JSON_FILE_NAME }}
+          tag: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
zip is already available hence removing it validated the zip creation in a branch 
link to branch run for only zip creation https://github.com/harsh-shah2-crest/logscale-azure-event-hub-collector/actions/runs/4280419929/jobs/7452167350
![image](https://user-images.githubusercontent.com/113084160/221514488-abb41ea3-4a30-4ccf-ada0-976ed37b4049.png)
