### PR TITLE
fix: update default consumer group

### DIFF
--- a/arm_template/arm.json
+++ b/arm_template/arm.json
@@ -30,7 +30,7 @@
             "metadata": {
                 "description": "Name of custom or default Consumer group  of Eventhub created for LogScale"
             },
-            "defaultValue": "$Default"
+            "defaultValue": "cwd"
         },
         "LogScaleHostURL": {
             "type": "string",


### PR DESCRIPTION
"$default" is not safe other temporary consumers may use this leading to lost data.